### PR TITLE
max-length for paragraphs

### DIFF
--- a/templates/html/page.hbs
+++ b/templates/html/page.hbs
@@ -128,6 +128,9 @@ a[aria-expanded="true"]::before {
 #content {
     padding: 20px;
     min-height: 100vh;
+    margin-left: 2rem;
+    margin-right: 2rem;
+    max-width: 48rem;
 }
 
 blockquote {
@@ -158,6 +161,10 @@ blockquote p {
     }
     #sidebarCollapse span {
         display: none;
+    }
+    #content {
+        margin-left: 1rem;
+        margin-right: 1rem;
     }
 }
     </style>


### PR DESCRIPTION
Heya, was having some trouble reading things. Probably because lines are a bit long. Generally 40-60 chars a line is nice to read, but with this font size it's about 80 chars.

Also added some margin to the content, so it feels nicely spaced; not smushed against the menu on the left.

Hope this might be helpful!

## Before
![2018-02-13-162025_1920x1080](https://user-images.githubusercontent.com/2467194/36157323-d22c6f40-10d9-11e8-84e5-ab3c38fb3439.png)

## After
![2018-02-13-162547_1920x1080](https://user-images.githubusercontent.com/2467194/36157672-a2ac2d4a-10da-11e8-85e0-eaa3b37cd4ad.png)
