### PR TITLE
count leading indent ahead of time before trimming it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ type Result<T> = std::result::Result<T, Error>;
 
 /// this removes the first space from each line of its input.
 ///
-/// this is useful because doc comments geneerally look like this:
+/// this is useful because doc comments generally look like this:
 ///
 /// ```text
 /// /// some words
@@ -53,13 +53,24 @@ pub fn strip_leading_space(s: &str) -> String {
         return String::new();
     }
 
+    // count the leading indent on the doc comment, in case it's not actually spaced over
+    let mut lead = usize::max_value();
+
+    for l in s.lines() {
+        if !l.is_empty() {
+            // count the number of spaces or tabs at the beginning, ignoring whether they're mixed
+            lead = std::cmp::min(lead, l.chars().take_while(|&c| c == ' ' || c == '\t').count());
+        }
+    }
+
     // s.len() is going to be long enough, as we're only dropping some characters,
     // so let's preallocate even though it's going to be slightly bigger
     let mut s = s.lines()
         .fold(String::with_capacity(s.len()), |mut s, line| {
             // some lines don't have any content, and so we should handle that.
             if !line.is_empty() {
-                s += &line[1..];
+                // the characters that `lead` was counting were one byte each, so this is valid
+                s += &line[lead..];
             }
 
             // we still want to retain the newlines in the output, but `lines` strips them


### PR DESCRIPTION
I have a lot of samples in egg-mode where i didn't add the leading space to doc comments, and i was very confused when i started reading my API docs and had a character missing from each line. `>_>`

The counting algorithm is [stolen from rustdoc](https://github.com/rust-lang/rust/blob/3ec5a99aaa0084d97a9e845b34fdf03d1462c475/src/librustdoc/passes/unindent_comments.rs#L82).