### PR TITLE
put page/package titles into each the page title

### DIFF
--- a/templates/html/page.hbs
+++ b/templates/html/page.hbs
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <title>Doxidize</title>
+    <title>{{#if title}}{{ title }} | {{/if}}{{ site-title }}</title>
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css">


### PR DESCRIPTION
fixes https://github.com/steveklabnik/doxidize/issues/77

Currently API docs pages don't get a title, so i made the template just emit the package title instead. It's probably worth wedging a proper title into there, but this is still an improvement.