### PR TITLE
Add doxidize.iml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Rust
 /target/
 **/*.rs.bk
+
+# IntelliJ IDEA
 .idea
+doxidize.iml


### PR DESCRIPTION
You've already gitignored the directory for IDEA-style IDE files, so you should probably go all the way and also gitignore the project manifest as well. I also took the liberty to add headings to make the purpose clear at a glance.

The other option that I typically use for projects where I'm not using the standard JetBrains gitignore contents, is to have `~/.gitignore` omit the IDE configuration and add `/.idea/` and `/<project>.iml` to `~/.git/info/exclude`.