### PR TITLE
check that manifest path exists and is absolute

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,3 @@
-use std::fmt;
-use std::path::PathBuf;
-
 /// Thrown whenever Cargo fails to run properly when getting data for `rustdoc`
 #[derive(Debug, Fail)]
 #[fail(display = "Cargo failed with status {}. stderr:\n{}", status, stderr)]
@@ -30,34 +27,5 @@ pub struct Json {
 
 /// An error when a command is run on a project that wasn't initialized for use with Doxidize.
 #[derive(Debug, Fail)]
-pub struct UninitializedProject {
-    /// the path for the project that wasn't initialized
-    pub location: PathBuf,
-    /// The subcommand that failed; used in the error display
-    pub command: &'static str,
-}
-
-// we have to impl Display manually for UninitializedProject because we want to
-// call .display() on the PathBuf, but that has a lifetime parameter, so the
-// attribute doesn't work.
-impl fmt::Display for UninitializedProject {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Package at {} doesn't look like it's ready for doxidize; consider `doxidize init` instead of `doxidize {}`", self.location.display(), self.command)
-    }
-}
-
-/// An error for the init command; if the project was already initialized, don't do it again
-#[derive(Debug, Fail)]
-pub struct InitializedProject {
-    /// the path for the project that was initialized
-    pub location: PathBuf,
-}
-
-// we have to impl Display manually for InitializedProject because we want to
-// call .display() on the PathBuf, but that has a lifetime parameter, so the
-// attribute doesn't work.
-impl fmt::Display for InitializedProject {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Package at {} looks like it's already using doxidize; remove the docs directory and/or Doxidize.toml and try again", self.location.display())
-    }
-}
+#[fail(display = "Project is not initialized. Try `doxidize init`")]
+pub struct UninitializedProject;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 extern crate comrak;
 #[macro_use]
 extern crate configure;
+#[macro_use]
 extern crate failure;
 #[macro_use]
 extern crate failure_derive;

--- a/src/ops/build.rs
+++ b/src/ops/build.rs
@@ -30,10 +30,7 @@ pub fn build(config: &Config, log: &Logger) -> Result<()> {
     let docs_dir = config.markdown_path();
 
     if !docs_dir.is_dir() {
-        return Err(error::UninitializedProject {
-            location: config.root_path().to_path_buf(),
-            command: "build",
-        }.into());
+        bail!(error::UninitializedProject);
     }
 
     // ensure that the docs dir exists in target

--- a/src/ops/update.rs
+++ b/src/ops/update.rs
@@ -19,10 +19,7 @@ pub fn update(config: &Config, log: &Logger) -> Result<()> {
 
     if !api_dir.is_dir() {
         // this folder is unilaterally created during init, even if there's no api to document
-        return Err(error::UninitializedProject {
-            location: config.root_path().to_path_buf(),
-            command: "update",
-        }.into());
+        bail!(error::UninitializedProject);
     }
 
     debug!(log, "walking the api docs folder for existing markdown files"; o!("dir" => api_dir.display()));

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -24,7 +24,7 @@ fn build_renders_readme() {
 
     util::cargo_init(dir_path).expect("Could not create sample crate");
 
-    let config = Config::with_manifest_path(dir_path.join("Cargo.toml"));
+    let config = Config::new(dir_path.join("Cargo.toml")).unwrap();
 
     doxidize::ops::init(&config, &log).expect("init failed");
 
@@ -81,7 +81,7 @@ fn build_renders_additional_markdown_files() {
 
     util::cargo_init(dir_path).expect("Could not create sample crate");
 
-    let config = Config::with_manifest_path(dir_path.join("Cargo.toml"));
+    let config = Config::new(dir_path.join("Cargo.toml")).unwrap();
 
     doxidize::ops::init(&config, &log).expect("init failed");
 
@@ -138,7 +138,7 @@ fn build_renders_nested_directories() {
 
     util::cargo_init(dir_path).expect("Could not create sample crate");
 
-    let config = Config::with_manifest_path(dir_path.join("Cargo.toml"));
+    let config = Config::new(dir_path.join("Cargo.toml")).unwrap();
 
     doxidize::ops::init(&config, &log).expect("init failed");
 

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -21,7 +21,7 @@ fn clean_deletes_directory_in_target() {
 
     util::cargo_init(dir_path).expect("Could not create sample crate");
 
-    let config = Config::with_manifest_path(dir_path.join("Cargo.toml"));
+    let config = Config::new(dir_path.join("Cargo.toml")).unwrap();
 
     doxidize::ops::init(&config, &log).expect("init failed");
     doxidize::ops::build(&config, &log).expect("build failed");


### PR DESCRIPTION
This commit also simplifies the errors used for reporting issues with
project initialization. Instead, the project folder is now logged at the
beginning.

Fixes #85.