### PR TITLE
remove the `public` path component in docs output

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -180,10 +180,6 @@ impl Config {
         self.output_path = Some(output_path)
     }
 
-    pub fn public_path(&self) -> PathBuf {
-        self.output_path().join("public")
-    }
-
     pub fn readme_path(&self) -> PathBuf {
         self.markdown_path().join("README.md")
     }

--- a/src/ops/build.rs
+++ b/src/ops/build.rs
@@ -37,7 +37,7 @@ pub fn build(config: &Config, log: &Logger) -> Result<()> {
     }
 
     // ensure that the docs dir exists in target
-    let mut target_dir = config.public_path();
+    let mut target_dir = config.output_path();
 
     // keep track of how far we're nested
     let mut base_nesting_count = 0;

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -51,9 +51,7 @@ testing"#,
 
     doxidize::ops::build(&config, &log).expect("build failed");
 
-    let mut output_dir = dir_path.join("target");
-    output_dir.push("docs");
-    output_dir.push("public");
+    let output_dir = dir_path.join("target").join("docs");
 
     let rendered_readme_path = output_dir.join("index.html");
 
@@ -108,9 +106,7 @@ testing"#,
 
     doxidize::ops::build(&config, &log).expect("generate failed");
 
-    let mut output_dir = dir_path.join("target");
-    output_dir.push("docs");
-    output_dir.push("public");
+    let output_dir = dir_path.join("target").join("docs");
 
     let rendered_guide_path = output_dir.join("guide.html");
 
@@ -169,9 +165,7 @@ testing"#,
 
     doxidize::ops::build(&config, &log).expect("build failed");
 
-    let mut output_dir = dir_path.join("target");
-    output_dir.push("docs");
-    output_dir.push("public");
+    let output_dir = dir_path.join("target").join("docs");
 
     let mut rendered_guide_path = output_dir.join("nested");
     rendered_guide_path.push("guide.html");


### PR DESCRIPTION
This commit changes the build to render docs at the target output, which
fixes a bug where `serve` would report the incorrect path to view the
docs.

Fixes #101.