### PR TITLE
refactor API Reference creation

### DIFF
--- a/docs/api/module-overview.md
+++ b/docs/api/module-overview.md
@@ -1,10 +1,10 @@
 # Module overview
 
-* [doxidize](/api/doxidize.html)
-  * [ops](/api/ops.html)
-  * [examples](/api/examples.html)
-    * [nested_module](/api/examples/nested_module.html)
-      * [next_level1](/api/examples/nested_module/next_level1.html)
-        * [next_level2](/api/examples/nested_module/next_level1/next_level2.html)
-          * [next_level3](/api/examples/nested_module/next_level1/next_level2/next_level3.html)
-      * [empty](/api/examples/nested_module/empty.html)
+* [doxidize](/doxidize/api/index.html)
+  * [examples](/doxidize/api/examples.html)
+    * [nested_module](/doxidize/api/examples/nested_module.html)
+      * [empty](/doxidize/api/examples/nested_module/empty.html)
+      * [next_level1](/doxidize/api/examples/nested_module/next_level1.html)
+        * [next_level2](/doxidize/api/examples/nested_module/next_level1/next_level2.html)
+          * [next_level3](/doxidize/api/examples/nested_module/next_level1/next_level2/next_level3.html)
+  * [ops](/doxidize/api/ops.html)

--- a/docs/api/struct-overview.md
+++ b/docs/api/struct-overview.md
@@ -1,4 +1,4 @@
 # Struct overview
 
-* [NestedStruct](/api/examples/nested_module/NestedStruct.html)
-* [Point](/api/examples/Point.html)
+* [NestedStruct](/doxidize/api/examples/nested_module/NestedStruct.html)
+* [Point](/doxidize/api/examples/Point.html)

--- a/docs/api/trait-overview.md
+++ b/docs/api/trait-overview.md
@@ -1,3 +1,3 @@
 # Trait overview
 
-* [Speak](/api/examples/Speak.html)
+* [Speak](/doxidize/api/examples/Speak.html)

--- a/src/ops/init/api.rs
+++ b/src/ops/init/api.rs
@@ -1,17 +1,21 @@
-use analysis::{self, DefKind};
+use analysis::{AnalysisHost, Def, DefKind, Id as DefId};
 use slog::Logger;
 
 use std::collections::{HashSet, VecDeque};
 use std::fs::{self, File};
 use std::io::prelude::*;
-use std::path::PathBuf;
+use std::iter;
+use std::path::{Path, PathBuf};
 
-use error;
 use cargo::{self, Target};
+use error;
+use strip_leading_space;
 use Config;
 use Result;
-use strip_leading_space;
 
+/// Creates the "API Reference" section.
+///
+/// Returns the paths of all files and directories created by this function.
 pub fn create(config: &Config, log: &Logger) -> Result<HashSet<PathBuf>> {
     // ensure that the api dir exists
     let api_dir = config.api_markdown_path();
@@ -29,15 +33,6 @@ pub fn create(config: &Config, log: &Logger) -> Result<HashSet<PathBuf>> {
 
     let roots = host.def_roots()?;
 
-    // we want to keep track of all modules/structs/traits for the module overview page
-    let mut module_set = HashSet::new();
-    let mut struct_set = HashSet::new();
-    let mut trait_set = HashSet::new();
-
-    // we also want to track the files/folders that we created so that `update` can clean up what
-    // was left
-    let mut file_set = HashSet::new();
-
     let id = roots.iter().find(|&&(_, ref name)| name == crate_name);
     let root_id = match id {
         Some(&(id, _)) => id,
@@ -48,335 +43,7 @@ pub fn create(config: &Config, log: &Logger) -> Result<HashSet<PathBuf>> {
         }
     };
 
-    let root_def = host.get_def(root_id)?;
-
-    let markdown_path = config.api_readme_path();
-
-    debug!(log, "creating README.md for api";
-    o!("file" => markdown_path.display()));
-    file_set.insert(markdown_path.clone());
-    let mut file = File::create(markdown_path)?;
-
-    file.write_all(
-        config
-            .handlebars()
-            .render(
-                "api",
-                &json!({"name": crate_name, "docs": strip_leading_space(&root_def.docs)}),
-            )?
-            .as_bytes(),
-    )?;
-
-    let ids = host.for_each_child_def(root_id, |id, _def| id).unwrap();
-
-    // this extra level of indent is for the log to go out of scope
-    // this whole thing really needs to be split up into functions, frankly
-    {
-        let log = log.new(o!("step" => "turning analysis into markdown"));
-        info!(log, "starting");
-        let mut queue = VecDeque::new();
-
-        for id in ids {
-            queue.push_back(id);
-
-            let def = host.get_def(id).unwrap();
-
-            match def.kind {
-                DefKind::Mod => (),
-                DefKind::Struct => (),
-                DefKind::Enum => (),
-                DefKind::Trait => (),
-                DefKind::Function => (),
-                DefKind::Type => (),
-                DefKind::Static => (),
-                DefKind::Const => (),
-                DefKind::Field => (),
-                DefKind::Tuple => continue,
-                DefKind::Local => continue,
-                // The below DefKinds are not supported in rls-analysis
-                // DefKind::Union => (String::from("union"), String::from("unions")),
-                // DefKind::Macro => (String::from("macro"), String::from("macros")),
-                // DefKind::Method => (String::from("method"), String::from("methods")),
-                _ => continue,
-            };
-        }
-
-        while let Some(id) = queue.pop_front() {
-            host.for_each_child_def(id, |id, _def| {
-                queue.push_back(id);
-            })?;
-
-            // Question: we could do this by cloning it in the call to for_each_child_def
-            // above/below; is that cheaper, or is this cheaper?
-            let def = host.get_def(id).unwrap();
-
-            // keep track of these kinds for their overview pages
-            match def.kind {
-                DefKind::Mod => {
-                    module_set.insert(id);
-                }
-                DefKind::Struct => {
-                    struct_set.insert(id);
-                }
-                DefKind::Trait => {
-                    trait_set.insert(id);
-                }
-                _ => (),
-            }
-
-            let template_name = match def.kind {
-                DefKind::Mod => "mod",
-                DefKind::Struct => "struct",
-                DefKind::Enum => "enum",
-                DefKind::Trait => "trait",
-                DefKind::Function => "function",
-                DefKind::Type => "type",
-                DefKind::Static => "static",
-                DefKind::Const => "const",
-                DefKind::Field => continue,
-                DefKind::Tuple => continue,
-                DefKind::Local => continue,
-                // The below DefKinds are not supported in rls-analysis
-                // DefKind::Union => (String::from("union"), String::from("unions")),
-                // DefKind::Macro => (String::from("macro"), String::from("macros")),
-                // DefKind::Method => (String::from("method"), String::from("methods")),
-                _ => continue,
-            };
-
-            let containing_path = name_to_path(&def.qualname);
-            let containing_path = api_dir.join(containing_path);
-
-            debug!(log, "creating"; o!("dir" => containing_path.display()));
-            fs::create_dir_all(&containing_path)?;
-            file_set.insert(containing_path.clone());
-
-            let markdown_path = containing_path.join(&format!("{}.md", def.name));
-            file_set.insert(markdown_path.clone());
-            debug!(log, "writing"; o!("file" => markdown_path.display()));
-
-            let mut file = File::create(markdown_path)?;
-
-            file.write_all(
-                config
-                    .handlebars()
-                    .render(
-                        template_name,
-                        &json!({"name": def.name, "docs": strip_leading_space(&def.docs), "signature": def.value}),
-                    )?
-                    .as_bytes(),
-            )?;
-        }
-
-        // now, time for modules:
-
-        #[derive(Debug)]
-        struct Module {
-            id: analysis::Id,
-            children: Vec<Module>,
-        }
-
-        let mut krate = Module {
-            id: root_id,
-            children: Vec::new(),
-        };
-
-        // is our call stack smaller than the module depth? hopefully! this is good enough for now
-        fn add_children(
-            parent: &mut Module,
-            possible_children: &HashSet<analysis::Id>,
-            host: &analysis::AnalysisHost,
-        ) {
-            let children: Vec<&analysis::Id> = possible_children
-                .iter()
-                .filter(|child| {
-                    let def = host.get_def(**child).unwrap();
-                    def.parent == Some(parent.id)
-                })
-                .collect();
-
-            // the base case!
-            if children.is_empty() {
-                return;
-            }
-
-            for child in children {
-                let mut module = Module {
-                    id: *child,
-                    children: Vec::new(),
-                };
-
-                add_children(&mut module, possible_children, host);
-
-                parent.children.push(module);
-            }
-        }
-
-        add_children(&mut krate, &module_set, host);
-
-        // time to write out the markdown
-
-        let markdown_path = config.api_module_overview_path();
-
-        file_set.insert(markdown_path.clone());
-        let mut file = File::create(markdown_path)?;
-
-        file.write_all(b"# Module overview\n\n")?;
-
-        fn print_tree(
-            node: &Module,
-            depth: usize,
-            host: &analysis::AnalysisHost,
-            file: &mut File,
-            config: &Config,
-        ) {
-            let def = host.get_def(node.id).unwrap();
-
-            let name = if def.name.is_empty() {
-                "doxidize".to_string()
-            } else {
-                def.name
-            };
-
-            // skip the initial crate name
-            let mut path: Vec<_> = def.qualname.split("::").skip(1).collect();
-            // pop off the final bit of the path, as that's the name, not the path itself
-            path.pop();
-
-            // the web uses / for paths, not \ or /
-            let path = path.join("/");
-            let base_url = if config.base_url().is_empty() {
-                String::new()
-            } else {
-                format!("/{}", config.base_url())
-            };
-
-            let url = if path.is_empty() {
-                format!("{}/api/{}.html", base_url, name)
-            } else {
-                format!("{}/api/{}/{}.html", base_url, path, name)
-            };
-
-            let line = format!(
-                "{}* [{}]({})\n",
-                ::std::iter::repeat("  ")
-                    .take(depth)
-                    .collect::<Vec<_>>()
-                    .join(""),
-                name,
-                url,
-            );
-            file.write_all(line.as_bytes()).unwrap();
-
-            if node.children.is_empty() {
-                return;
-            }
-
-            for child in &node.children {
-                print_tree(child, depth + 1, host, file, config);
-            }
-        }
-
-        print_tree(&krate, 0, host, &mut file, config);
-
-        // struct overview
-
-        let markdown_path = config.api_struct_overview_path();
-
-        file_set.insert(markdown_path.clone());
-        let mut file = File::create(markdown_path)?;
-
-        file.write_all(b"# Struct overview\n\n")?;
-
-        for id in struct_set {
-            let def = host.get_def(id).unwrap();
-
-            let name = if def.name.is_empty() {
-                "doxidize".to_string()
-            } else {
-                def.name
-            };
-
-            // skip the initial crate name
-            let mut path: Vec<_> = def.qualname.split("::").skip(1).collect();
-            // pop off the final bit of the path, as that's the name, not the path itself
-            path.pop();
-
-            // the web uses / for paths, not \ or /
-            let path = path.join("/");
-            let base_url = if config.base_url().is_empty() {
-                String::from("")
-            } else {
-                format!("/{}", config.base_url())
-            };
-
-            let url = if path.is_empty() {
-                format!("{}/api/{}.html", base_url, name)
-            } else {
-                format!("{}/api/{}/{}.html", base_url, path, name)
-            };
-
-            file.write_all(format!("* [{}]({})\n", name, url).as_bytes())?
-        }
-
-        // trait overview
-
-        let markdown_path = config.api_trait_overview_path();
-
-        file_set.insert(markdown_path.clone());
-        let mut file = File::create(markdown_path)?;
-
-        file.write_all(b"# Trait overview\n\n")?;
-
-        for id in trait_set {
-            let def = host.get_def(id).unwrap();
-
-            let name = if def.name.is_empty() {
-                "doxidize".to_string()
-            } else {
-                def.name
-            };
-
-            // skip the initial crate name
-            let mut path: Vec<_> = def.qualname.split("::").skip(1).collect();
-            // pop off the final bit of the path, as that's the name, not the path itself
-            path.pop();
-
-            // the web uses / for paths, not \ or /
-            let path = path.join("/");
-            let base_url = if config.base_url().is_empty() {
-                String::from("")
-            } else {
-                format!("/{}", config.base_url())
-            };
-
-            let url = if path.is_empty() {
-                format!("{}/api/{}.html", base_url, name)
-            } else {
-                format!("{}/api/{}/{}.html", base_url, path, name)
-            };
-
-            file.write_all(format!("* [{}]({})\n", name, url).as_bytes())?
-        }
-
-        info!(log, "done");
-    }
-
-    Ok(file_set)
-}
-
-fn name_to_path(name: &str) -> PathBuf {
-    // we skip the first bit since it's the crate name
-    let mut path = name.split("::")
-        .skip(1)
-        .fold(PathBuf::new(), |mut path, component| {
-            path.push(component);
-            path
-        });
-
-    // we want the containing directory here, so we *also* have to pop off the last part
-    path.pop();
-
-    path
+    compile_analysis_to_markdown(config, log, host, api_dir, crate_name, root_id)
 }
 
 /// Generate save analysis data of a crate to be used later by the RLS library later and load it
@@ -395,11 +62,253 @@ fn generate_and_load_analysis(config: &Config, target: &Target, log: &Logger) ->
     Ok(())
 }
 
+/// Compile the crate analysis into markdown files.
+fn compile_analysis_to_markdown<P: AsRef<Path>>(
+    config: &Config,
+    log: &Logger,
+    host: &AnalysisHost,
+    api_dir: P,
+    crate_name: &str,
+    root_id: DefId,
+) -> Result<HashSet<PathBuf>> {
+    let log = log.new(o!("step" => "compiling analysis into markdown"));
+
+    // Keep track of the list of files and directories that we created. This is needed so that
+    // `update` can clean up what was left.
+    let mut created_paths = HashSet::new();
+
+    // First, compile the crate docs into the root README.
+    debug!(log, "creating README.md for api");
+    let api_readme_path = config.api_readme_path();
+    o!("file" => api_readme_path.display());
+
+    let root_def = host.get_def(root_id)?;
+    fs::write(
+        &api_readme_path,
+        config.handlebars().render(
+            "api",
+            &json!({"name": crate_name, "docs": strip_leading_space(&root_def.docs)}),
+        )?,
+    )?;
+    created_paths.insert(api_readme_path);
+
+    // We have a separate overview page for modules, structs, and traits. The module page
+    // contains a tree of existing modules, so we handle it separately later. Since
+    // structs and traits are simpler, we just save their IDs as we come across them.
+    let mut struct_ids = vec![];
+    let mut trait_ids = vec![];
+
+    let mut queue = VecDeque::new();
+    queue.extend(host.for_each_child_def(root_id, |id, _def| id)?);
+
+    // Write markdown for each def.
+    while let Some(id) = queue.pop_front() {
+        let def = host.get_def(id)?;
+
+        // Push any children of the current def onto the queue.
+        queue.extend(host.for_each_child_def(id, |id, _def| id)?);
+        match def.kind {
+            DefKind::Struct => {
+                struct_ids.push(id);
+            }
+            DefKind::Trait => {
+                trait_ids.push(id);
+            }
+            _ => (),
+        }
+
+        let containing_path = api_dir.as_ref().join(name_to_path(&def.qualname));
+        debug!(log, "creating"; o!("dir" => containing_path.display()));
+        fs::create_dir_all(&containing_path)?;
+        created_paths.insert(containing_path.clone());
+
+        let markdown_path = containing_path.join(&format!("{}.md", def.name));
+        let template_name = match template_for_defkind(def.kind) {
+            Some(template_name) => template_name,
+            None => continue,
+        };
+        let markdown = config.handlebars().render(
+            template_name,
+            &json!({
+                "name": def.name,
+                "docs": strip_leading_space(&def.docs),
+                "signature": def.value
+            }),
+        )?;
+        debug!(log, "writing"; o!("file" => markdown_path.display()));
+        fs::write(&markdown_path, markdown)?;
+        created_paths.insert(markdown_path);
+    }
+
+    // Write the "All Modules" hierarchy file.
+    let module_tree = ModuleTree::new(&host, root_id)?;
+    let mut module_overview = File::create(config.api_module_overview_path())?;
+
+    debug!(log, "writing"; o!("file" => config.api_module_overview_path().display()));
+    writeln!(module_overview, "# Module overview\n")?;
+    module_tree.write(host, config.base_url(), &mut module_overview, 0)?;
+    created_paths.insert(config.api_module_overview_path().to_owned());
+
+    debug!(log, "writing"; o!("file" => config.api_struct_overview_path().display()));
+    let mut struct_overview = File::create(config.api_struct_overview_path())?;
+    writeln!(struct_overview, "# Struct overview\n")?;
+    struct_ids.sort_by_key(|id| host.get_def(*id).unwrap().name);
+
+    for id in struct_ids {
+        let def = host.get_def(id)?;
+        writeln!(
+            struct_overview,
+            "* {}",
+            link_for_def(config.base_url(), &def)
+        )?;
+    }
+    created_paths.insert(config.api_struct_overview_path().to_owned());
+
+    debug!(log, "writing"; o!("file" => config.api_trait_overview_path().display()));
+    let mut trait_overview = File::create(config.api_trait_overview_path())?;
+    writeln!(trait_overview, "# Trait overview\n")?;
+
+    trait_ids.sort_by_key(|id| host.get_def(*id).unwrap().name);
+    for id in trait_ids {
+        let def = host.get_def(id)?;
+        writeln!(
+            trait_overview,
+            "* {}",
+            link_for_def(config.base_url(), &def)
+        )?;
+    }
+    created_paths.insert(config.api_trait_overview_path().to_owned());
+
+    info!(log, "done");
+
+    Ok(created_paths)
+}
+
+/// Returns the name of the template for a given DefKind.
+fn template_for_defkind(def_kind: DefKind) -> Option<&'static str> {
+    let template_name = match def_kind {
+        DefKind::Mod => "mod",
+        DefKind::Struct => "struct",
+        DefKind::Enum => "enum",
+        DefKind::Trait => "trait",
+        DefKind::Function => "function",
+        DefKind::Type => "type",
+        DefKind::Static => "static",
+        DefKind::Const => "const",
+        DefKind::Field => return None,
+        DefKind::Tuple => return None,
+        DefKind::Local => return None,
+        // The below DefKinds are not supported in rls-analysis
+        // DefKind::Union => ...
+        // DefKind::Macro => ...
+        // DefKind::Method => ...
+        _ => return None,
+    };
+
+    Some(template_name)
+}
+
+/// Returns a markdown-formatted link to the API documentation for the Def.
+///
+/// The link is relative from the documentation root.
+fn link_for_def(base_url: &str, def: &Def) -> String {
+    // The qualname contains the entire path, including the crate name and the item name itself. We
+    // don't need either of these, so we just remove them.
+    let mut path = def.qualname.split("::").skip(1).collect::<Vec<_>>();
+    path.pop();
+
+    let base_url = format!("/{}", base_url);
+
+    let (name, url) = if def.name.is_empty() {
+        // If the name is empty, we're probably looking at the root crate. The link should point to
+        // the crate overview, and the name should be the first component of the qualname.
+        let name = def.qualname.split("::").next().unwrap();
+        let url = format!("{}/api/index.html", base_url);
+        (name, url)
+    } else {
+        let path = if path.is_empty() {
+            String::from("")
+        } else {
+            path.join("/") + "/"
+        };
+
+        let url = format!("{}/api/{}{}.html", base_url, path, def.name);
+        (def.name.as_str(), url)
+    };
+
+    format!("[{}]({})", name, url)
+}
+
+#[derive(Debug)]
+struct ModuleTree {
+    id: DefId,
+    children: Vec<ModuleTree>,
+}
+
+impl ModuleTree {
+    fn new(host: &AnalysisHost, root_id: DefId) -> Result<ModuleTree> {
+        let mut child_module_ids = host
+            .for_each_child_def(root_id, |id, def| match def.kind {
+                DefKind::Mod => Some(id),
+                _ => None,
+            })?
+            .into_iter()
+            .flat_map(|id| id)
+            .collect::<Vec<_>>();
+
+        child_module_ids.sort_by_key(|id| host.get_def(*id).unwrap().name);
+        let mut children = vec![];
+        for id in child_module_ids {
+            children.push(ModuleTree::new(host, id.clone())?);
+        }
+
+        Ok(ModuleTree {
+            id: root_id,
+            children,
+        })
+    }
+
+    fn write<W: Write>(
+        &self,
+        host: &AnalysisHost,
+        base_url: &str,
+        writer: &mut W,
+        depth: usize,
+    ) -> Result<()> {
+        let def = host.get_def(self.id)?;
+
+        let indent = iter::repeat("  ").take(depth).collect::<String>();
+        writeln!(writer, "{}* {}", indent, link_for_def(base_url, &def))?;
+
+        for child in &self.children {
+            child.write(host, base_url, writer, depth + 1)?;
+        }
+
+        Ok(())
+    }
+}
+
+fn name_to_path(name: &str) -> PathBuf {
+    // we skip the first bit since it's the crate name
+    let mut path = name
+        .split("::")
+        .skip(1)
+        .fold(PathBuf::new(), |mut path, component| {
+            path.push(component);
+            path
+        });
+
+    // we want the containing directory here, so we *also* have to pop off the last part
+    path.pop();
+
+    path
+}
+
 #[cfg(test)]
 mod tests {
     mod name_to_path {
-        use std::path::PathBuf;
         use super::super::name_to_path;
+        use std::path::PathBuf;
 
         #[test]
         fn nest_level1() {


### PR DESCRIPTION
Split the large `create` function into much smaller parts.

Fixes #100.